### PR TITLE
Feature/gpg

### DIFF
--- a/conans/client/tools/gpg.py
+++ b/conans/client/tools/gpg.py
@@ -1,5 +1,4 @@
 import tempfile
-import gnupg
 import platform
 from conans.errors import ConanException
 import os
@@ -8,6 +7,7 @@ _global_output = None
 
 
 def _get_gpg():
+    import gnupg
     try:
         _GPG_HOME_DIR = tempfile.mkdtemp(suffix="_conan_gpg")
         gpgbinary = "gpg.exe" if platform.system() == "Windows" else "gpg"

--- a/conans/client/tools/gpg.py
+++ b/conans/client/tools/gpg.py
@@ -31,12 +31,16 @@ def _get_keys(gpg, pubkey, keyserver):
         import_key_result = gpg.import_keys(pubkey)
 
     # check if key was imported correctly
-    if "problem" in import_key_result.results[0]:
-        raise ConanException("failed to import public key from file: %s "
-                             % import_key_result.problem_reason[import_key_result.results[0]["problem"]])
+    try:
+        # This was failing because results was empty (in windows). It might depend on the gpg version
+        if "problem" in import_key_result.results[0]:
+            raise ConanException("failed to import public key from file: %s "
+                                 % import_key_result.problem_reason[import_key_result.results[0]["problem"]])
 
-    fingerprint = import_key_result.fingerprints[0]
-    return fingerprint
+        fingerprint = import_key_result.fingerprints[0]
+        return fingerprint
+    except Exception as e:
+        raise ConanException("failed to import public key from file: %s " % str(e))
 
 
 def _verify(gpg, sig_file, data_file):

--- a/conans/client/tools/net.py
+++ b/conans/client/tools/net.py
@@ -22,10 +22,9 @@ def get(url, md5='', sha1='', sha256='', gpg_signature='', gpg_pubkey='', destin
         check_sha1(filename, sha1)
     if sha256:
         check_sha256(filename, sha256)
-    
+
     if gpg_signature and gpg_pubkey:
-        verify_gpg_sig(filename,gpg_pubkey,gpg_signature)
-    
+        verify_gpg_sig(filename, gpg_pubkey, gpg_signature)
     elif gpg_signature or gpg_pubkey:
         raise ConanException("must provide both gpg_signature and gpg_pubkey")
 

--- a/conans/test/functional/gpg_verify_test.py
+++ b/conans/test/functional/gpg_verify_test.py
@@ -1,7 +1,6 @@
 import unittest
 import tarfile
 import os
-import tempfile
 import platform
 import gnupg
 
@@ -113,11 +112,6 @@ qL7yzZr/qpkNLbp2djiZw3erAtxgRVUTMYrVF1OSkg==
 
 class GPGVerifyTest(unittest.TestCase):
     def setUp(self):
-        """self._data_file = "gpg_test_data.tar.gz"
-        self._sig_file = "gpg_test_data.tar.gz.sig"
-        self._key_file = "pubkey.txt"
-        self._ascii_sig_file = "gpg_test_data.tar.gz.asc"""
-
         tmp_folder = temp_folder()
         basename = os.path.join(tmp_folder, "gpg_test_data")
         self.basename = basename
@@ -134,7 +128,7 @@ class GPGVerifyTest(unittest.TestCase):
 
         # import private key
         gpgbinary = "gpg.exe" if platform.system() == "Windows" else "gpg"
-        gpghome = tempfile.mkdtemp()
+        gpghome = temp_folder()
 
         _gpg = gnupg.GPG(gpgbinary=gpgbinary, gnupghome=gpghome)
         _gpg.import_keys(GPG_PRIVATE_KEY)


### PR DESCRIPTION
I have finished reviewing this:
- Fixed some more minor style and pep8 things
- Was able to run the tests both in Win (fixed a minor thing, could be related to different gpg versions).
- The tests were generating files in the repo, if the tearDown or something fails, the repo is left dirty. I have just generated the files in a temporary folder.

I think this should be enough to get to 1.3 as experimental. However, after merging to develop, we will move the tests to the auxiliary conan tests repository, so we don't make compulsory to everybody running the conan test suite to install gpg manually in their respective platforms, just to pass the test suite. Don't worry about this, we will do it.